### PR TITLE
Change event sorting to be based on minutes since midnight (local time)

### DIFF
--- a/main.js
+++ b/main.js
@@ -42,9 +42,11 @@
       })
       .sort(function(a, b) {
         // Start the list at midnight regardless of the user's timezone
-        if (a.timeString < b.timeString) return -1;
-        if (a.timeString > b.timeString) return 1;
-        return 0;
+        var tl = [a, b].map(function(x) {
+          var d = x.dateTime;
+          return (d.getHours() * 60 + d.getMinutes());
+        });
+        return (tl[0] - tl[1]);
       })
       .forEach(function(event) {
         var li = document.createElement('li');


### PR DESCRIPTION
Thanks for this great tool! I'm encountering a couple of minor issues with the event sorting:
- The sorting is based on string comparison so, for example, "11:00 PM" is sorted after "11:00 AM" but before "11:45 AM".
- It seems the time string can also vary depending on the browser (probably related to locale), e.g., in my environment, Chrome shows "02:00 PM" while Firefox shows "2:00 PM", resulting in different orderings.

The commit in this pull request changes the sorting to be based on "minutes since midnight (local time)" to avoid these issues. Please check if it can be applied. Thanks!